### PR TITLE
bump NServiceBus packages

### DIFF
--- a/src/Tests.AzureStorage2/Tests.AzureStorage2.csproj
+++ b/src/Tests.AzureStorage2/Tests.AzureStorage2.csproj
@@ -18,10 +18,10 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.30.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NServiceBus.Persistence.AzureStorage" Version="2.4.2" />
-    <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.1.0-beta.1" />
+    <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.2.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Nunit" Version="3.13.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.6.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
   </ItemGroup>
 

--- a/src/Tests.AzureTable3/Tests.AzureTable3.csproj
+++ b/src/Tests.AzureTable3/Tests.AzureTable3.csproj
@@ -17,11 +17,11 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.30.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="3.1.0" />
-    <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.1.0" />
+    <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="3.2.0" />
+    <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.2.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Nunit" Version="3.13.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.6.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
   </ItemGroup>
 

--- a/src/Tests.AzureTable4/BaseEndpoint.cs
+++ b/src/Tests.AzureTable4/BaseEndpoint.cs
@@ -7,7 +7,12 @@
 
     public class BaseEndpoint : IEndpointSetupTemplate
     {
-        public virtual Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
+        public virtual async Task<EndpointConfiguration> GetConfiguration(
+            RunDescriptor runDescriptor,
+            EndpointCustomizationConfiguration endpointCustomizationConfiguration,
+#pragma warning disable PS0013 // Add a CancellationToken parameter type argument
+            Func<EndpointConfiguration, Task> configurationBuilderCustomization)
+#pragma warning restore PS0013
         {
             var endpointConfiguration = new EndpointConfiguration(endpointCustomizationConfiguration.EndpointName);
 
@@ -19,9 +24,9 @@
 
             endpointConfiguration.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
 
-            configurationBuilderCustomization(endpointConfiguration);
+            await configurationBuilderCustomization(endpointConfiguration);
 
-            return Task.FromResult(endpointConfiguration);
+            return endpointConfiguration;
         }
     }
 }

--- a/src/Tests.AzureTable4/Tests.AzureTable4.csproj
+++ b/src/Tests.AzureTable4/Tests.AzureTable4.csproj
@@ -17,11 +17,11 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.30.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="4.0.0-beta.1" />
-    <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.0.0-beta.1" />
+    <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="4.0.0-rc.2" />
+    <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.0.0-rc.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Nunit" Version="3.13.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-beta.1" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-rc.3" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps NServiceBus.Persistence.AzureTable from 3.1.0 to 4.0.0-rc.2.

---
updated-dependencies:
- dependency-name: NServiceBus.Persistence.AzureTable dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>

Bump NServiceBus.Persistence.CosmosDB from 1.1.0-beta.1 to 2.0.0-rc.2

Bumps NServiceBus.Persistence.CosmosDB from 1.1.0-beta.1 to 2.0.0-rc.2.

---
updated-dependencies:
- dependency-name: NServiceBus.Persistence.CosmosDB dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>
Conflicts:
	src/Tests.AzureTable3/Tests.AzureTable3.csproj
	src/Tests.AzureTable4/Tests.AzureTable4.csproj

Bump NServiceBus.AcceptanceTesting from 7.6.0 to 8.0.0-rc.3

Bumps NServiceBus.AcceptanceTesting from 7.6.0 to 8.0.0-rc.3.

---
updated-dependencies:
- dependency-name: NServiceBus.AcceptanceTesting dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>